### PR TITLE
feat: migrate to OpenAI SDK v1+, add tools, signed webhooks, and premium TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,67 @@
 # llm_convo
 
-Use ChatGPT over Twilio to create an AI phone agent (works for incoming or outgoing calls).
+Build an AI phone agent powered by ChatGPT and Twilio. Supports incoming and outgoing calls, function calling (tools), multiple TTS providers, and signed webhook validation.
 
 ### How it works
 
-Twilio Webhook -> Flask app -> Twilio Media Stream (websocket) -> Whisper -> ChatGPT API -> Google TTS -> Twilio Play Audio
+```
+Twilio Webhook → Flask app → Twilio Media Stream (websocket)
+   → Whisper (speech-to-text) → ChatGPT (LLM + optional tools)
+   → TTS (gTTS / OpenAI / ElevenLabs) → Twilio <Play>
+```
+
+### Features
+
+- **OpenAI SDK v1+** with automatic retries on transient errors (rate limits, timeouts).
+- **Function calling (tools)** — let the LLM look up customer data, schedule appointments, etc.
+- **Conversation history truncation** to avoid blowing the context window on long calls.
+- **Multiple TTS providers**: Google TTS (default), OpenAI TTS, ElevenLabs.
+- **Twilio request signature validation** — webhooks are rejected if the signature is missing or invalid.
+- **Robust error handling** — a failed LLM call or transcription does not crash the bridge; the agent says a fallback phrase and continues.
+- **Configurable transcription language** instead of hard-coded English.
+- **UUID-based audio cache keys** to avoid collisions across utterances.
 
 ### Setup
 
-1. `pip install git+https://github.com/sshh12/llm_convo`
-2. Environment Variables
-
-```
-OPENAI_API_KEY=
-TWILIO_ACCOUNT_SID=
-TWILIO_AUTH_TOKEN=
-TWILIO_PHONE_NUMBER=
+```bash
+pip install git+https://github.com/sshh12/llm_convo
 ```
 
+Environment variables:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `OPENAI_API_KEY` | yes | OpenAI chat completions + TTS. |
+| `TWILIO_ACCOUNT_SID` | yes (phone) | Twilio account ID. |
+| `TWILIO_AUTH_TOKEN` | yes (phone) | Used for API calls and webhook signature validation. |
+| `TWILIO_PHONE_NUMBER` | yes (phone) | The "from" number for outgoing calls. |
+| `ELEVENLABS_API_KEY` | optional | Only if using `ElevenLabsTTS`. |
 
 ### Demo
 
 #### Basic Text Chat
 
-Try `python examples\keyboard_chat_with_gpt.py` to chat with GPT through terminal.
+```bash
+python examples/keyboard_chat_with_gpt.py
+```
 
-#### Twilio Helpline
+#### Twilio Helpline (incoming calls)
 
-Try `python examples\twilio_ngrok_ml_rhyme_hotline.py --preload_whisper --start_ngrok`. This requires whisper installed locally.
+```bash
+python examples/twilio_ngrok_ml_rhyme_hotline.py --preload_whisper --start_ngrok
+```
 
-This will create an ngrok tunnel and provide a webhook URL to point to in Twilio settings for a purchased phone number.
+This creates an ngrok tunnel and prints a webhook URL to point to in Twilio settings for a purchased phone number.
 
-<img width="1169" alt="chrome_VZSfJHN6FV" src="https://github.com/sshh12/llm_convo/assets/6625384/1fe9468d-0eb3-4309-9b81-1d2f3d02c353">
+#### Twilio Pizza Order (outgoing call)
 
-https://github.com/sshh12/llm_convo/assets/6625384/cfd3826e-dd0a-44cd-936d-d6c339f1edcf
+```bash
+python examples/twilio_ngrok_pizza_order.py --preload_whisper --start_ngrok --phone_number "+1XXXXXXXXXX"
+```
 
-#### Twilio Pizza Order
+### Code Snippets
 
-Try `python examples\twilio_ngrok_pizza_order.py --preload_whisper --start_ngrok --phone_number "+1.........."`. This requires whisper installed locally.
-
-This will create an ngrok tunnel and provide a webhook URL to point to in Twilio settings for a purchased phone number. Once the webhook is updated, it will start an outgoing call to the provided phone number.
-
-#### Code Snippets
-
-Setup a Haiku hotline with Twilio that can be called like any other phone number.
+#### Basic Haiku hotline
 
 ```python
 from gevent import monkey
@@ -58,28 +76,14 @@ import time
 
 logging.getLogger().setLevel(logging.INFO)
 
-tws = TwilioServer(remote_host="abcdef.ngrok.app", port=8080, static_dir=r"/path/to/static")
-# Point twilio voice webhook to https://abcdef.ngrok.app/audio/incoming-voice
+tws = TwilioServer(remote_host="abcdef.ngrok.app", port=8080, static_dir="/path/to/static")
+# Point twilio voice webhook to https://abcdef.ngrok.app/incoming-voice
 tws.start()
 agent_a = OpenAIChat(
     system_prompt="You are a Haiku Assistant. Answer whatever the user wants but always in a rhyming Haiku.",
     init_phrase="This is Haiku Bot, how can I help you.",
+    model="gpt-4o-mini",
 )
-# agent_a = OpenAIChat(
-#     system_prompt="""
-# You are an ordering bot that is going to call a pizza place an order a pizza.
-# When you need to say numbers space them out (e.g. 1 2 3) and do not respond with abbreviations.
-# If they ask for information not known, make something up that's reasonable.
-
-# The customer's details are:
-# * Address: 1234 Candyland Road, Apt 506
-# * Credit Card: 1234 5555 8888 9999 (CVV: 010)
-# * Name: Bob Joe
-# * Order: 1 large pizza with only pepperoni
-# """,
-#     init_phrase="Hi, I would like to order a pizza.",
-# )
-
 
 def run_chat(sess):
     agent_b = TwilioCaller(sess)
@@ -87,9 +91,83 @@ def run_chat(sess):
         time.sleep(0.1)
     run_conversation(agent_a, agent_b)
 
-
 tws.on_session = run_chat
-
-# You can also have ChatGPT actually start the call, e.g. for automated ordering
-# tws.start_call("+18321231234")
 ```
+
+#### Function calling (tools)
+
+Let the LLM look up order status by calling Python functions:
+
+```python
+from llm_convo.agents import OpenAIChat
+
+def lookup_order(order_id: str) -> str:
+    # Replace with your DB lookup, API call, etc.
+    return f"Order {order_id} is out for delivery, arriving 6:30pm."
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "lookup_order",
+            "description": "Look up the current status of an order by its ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "order_id": {"type": "string", "description": "The order ID."}
+                },
+                "required": ["order_id"],
+            },
+        },
+    }
+]
+
+agent = OpenAIChat(
+    system_prompt="You are a customer support agent for Pizza Palace.",
+    init_phrase="Hi, this is Pizza Palace — how can I help?",
+    tools=tools,
+    tool_handlers={"lookup_order": lookup_order},
+)
+```
+
+#### Higher-quality voices
+
+```python
+from llm_convo.audio_output import OpenAITTS, ElevenLabsTTS
+from llm_convo.agents import TwilioCaller
+
+# OpenAI TTS (alloy, echo, fable, onyx, nova, shimmer)
+caller = TwilioCaller(session, tts=OpenAITTS(voice="nova", model="tts-1-hd"))
+
+# ElevenLabs (requires `pip install elevenlabs`)
+caller = TwilioCaller(session, tts=ElevenLabsTTS(voice_id="21m00Tcm4TlvDq8ikWAM"))
+```
+
+#### Disable signature validation (local dev only)
+
+```python
+tws = TwilioServer(..., validate_signature=False)
+```
+
+> **Do not** disable signature validation in production — without it, anyone who knows your webhook URL can trigger calls on your account.
+
+### Architecture
+
+| Module | Purpose |
+|---|---|
+| [`agents.py`](llm_convo/agents.py) | Abstract `ChatAgent` plus implementations for OpenAI, microphone, terminal and Twilio. |
+| [`openai_io.py`](llm_convo/openai_io.py) | OpenAI SDK v1+ wrapper with retries, history truncation and tool calling. |
+| [`audio_input.py`](llm_convo/audio_input.py) | Whisper transcription from microphone and Twilio media streams. |
+| [`audio_output.py`](llm_convo/audio_output.py) | TTS providers: Google, OpenAI, ElevenLabs. |
+| [`twilio_io.py`](llm_convo/twilio_io.py) | Flask + websocket bridge to Twilio Media Streams. |
+| [`conversation.py`](llm_convo/conversation.py) | Drives turn-taking between two `ChatAgent`s. |
+
+### Notes on costs
+
+Rough order-of-magnitude per minute of call:
+
+- Twilio voice: ~$0.013/min (US)
+- OpenAI `gpt-4o-mini`: a few tenths of a cent per turn
+- OpenAI TTS `tts-1`: ~$0.015 / 1k chars
+- ElevenLabs: varies by plan
+- Whisper (local): free, but needs a GPU for low latency

--- a/llm_convo/agents.py
+++ b/llm_convo/agents.py
@@ -1,10 +1,14 @@
-from typing import List, Optional
+from typing import List, Optional, Dict, Any, Callable
 from abc import ABC, abstractmethod
+import logging
 
 from llm_convo.audio_input import WhisperMicrophone
 from llm_convo.audio_output import TTSClient, GoogleTTS
 from llm_convo.openai_io import OpenAIChatCompletion
 from llm_convo.twilio_io import TwilioCallSession
+
+
+FALLBACK_ERROR_PHRASE = "Sorry, I'm having trouble responding right now. Could you repeat that?"
 
 
 class ChatAgent(ABC):
@@ -35,16 +39,32 @@ class TerminalInPrintOut(ChatAgent):
 
 
 class OpenAIChat(ChatAgent):
-    def __init__(self, system_prompt: str, init_phrase: Optional[str] = None, model: Optional[str] = None):
-        self.openai_chat = OpenAIChatCompletion(system_prompt=system_prompt, model=model)
+    def __init__(
+        self,
+        system_prompt: str,
+        init_phrase: Optional[str] = None,
+        model: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_handlers: Optional[Dict[str, Callable[..., str]]] = None,
+        max_history: int = 20,
+    ):
+        self.openai_chat = OpenAIChatCompletion(
+            system_prompt=system_prompt,
+            model=model,
+            tools=tools,
+            tool_handlers=tool_handlers,
+            max_history=max_history,
+        )
         self.init_phrase = init_phrase
 
     def get_response(self, transcript: List[str]) -> str:
-        if len(transcript) > 0:
-            response = self.openai_chat.get_response(transcript)
-        else:
-            response = self.init_phrase
-        return response
+        if len(transcript) == 0:
+            return self.init_phrase or ""
+        try:
+            return self.openai_chat.get_response(transcript)
+        except Exception:
+            logging.exception("OpenAIChat.get_response failed; returning fallback phrase.")
+            return FALLBACK_ERROR_PHRASE
 
 
 class TwilioCaller(ChatAgent):
@@ -54,10 +74,15 @@ class TwilioCaller(ChatAgent):
         self.thinking_phrase = thinking_phrase
 
     def _say(self, text: str):
-        key, tts_fn = self.session.get_audio_fn_and_key(text)
-        self.speaker.text_to_mp3(text, output_fn=tts_fn)
-        duration = self.speaker.get_duration(tts_fn)
-        self.session.play(key, duration)
+        if not text:
+            return
+        try:
+            key, tts_fn = self.session.get_audio_fn_and_key(text)
+            self.speaker.text_to_mp3(text, output_fn=tts_fn)
+            duration = self.speaker.get_duration(tts_fn)
+            self.session.play(key, duration)
+        except Exception:
+            logging.exception("Failed to synthesize/play text on Twilio call.")
 
     def get_response(self, transcript: List[str]) -> str:
         if len(transcript) > 0:

--- a/llm_convo/audio_input.py
+++ b/llm_convo/audio_input.py
@@ -4,6 +4,7 @@ import tempfile
 import queue
 import functools
 import logging
+from typing import Optional
 
 from pydub import AudioSegment
 import speech_recognition as sr
@@ -17,25 +18,29 @@ def get_whisper_model(size: str = "large"):
 
 
 class WhisperMicrophone:
-    def __init__(self):
+    def __init__(self, language: Optional[str] = "english"):
         self.audio_model = get_whisper_model()
         self.recognizer = sr.Recognizer()
         self.recognizer.energy_threshold = 500
         self.recognizer.pause_threshold = 0.8
         self.recognizer.dynamic_energy_threshold = False
+        self.language = language
 
     def get_transcription(self) -> str:
-        with sr.Microphone(sample_rate=16000) as source:
-            logging.info("Waiting for mic...")
-            with tempfile.TemporaryDirectory() as tmp:
-                tmp_path = os.path.join(tmp, "mic.wav")
-                audio = self.recognizer.listen(source)
-                data = io.BytesIO(audio.get_wav_data())
-                audio_clip = AudioSegment.from_file(data)
-                audio_clip.export(tmp_path, format="wav")
-                result = self.audio_model.transcribe(tmp_path, language="english")
-            predicted_text = result["text"]
-        return predicted_text
+        try:
+            with sr.Microphone(sample_rate=16000) as source:
+                logging.info("Waiting for mic...")
+                with tempfile.TemporaryDirectory() as tmp:
+                    tmp_path = os.path.join(tmp, "mic.wav")
+                    audio = self.recognizer.listen(source)
+                    data = io.BytesIO(audio.get_wav_data())
+                    audio_clip = AudioSegment.from_file(data)
+                    audio_clip.export(tmp_path, format="wav")
+                    result = self.audio_model.transcribe(tmp_path, language=self.language)
+                return result["text"]
+        except Exception:
+            logging.exception("WhisperMicrophone transcription failed.")
+            return ""
 
 
 class _TwilioSource(sr.AudioSource):
@@ -64,25 +69,30 @@ class _QueueStream:
 
 
 class WhisperTwilioStream:
-    def __init__(self):
+    def __init__(self, language: Optional[str] = "english"):
         self.audio_model = get_whisper_model()
         self.recognizer = sr.Recognizer()
         self.recognizer.energy_threshold = 300
         self.recognizer.pause_threshold = 2.5
         self.recognizer.dynamic_energy_threshold = False
         self.stream = None
+        self.language = language
 
     def get_transcription(self) -> str:
         self.stream = _QueueStream()
-        with _TwilioSource(self.stream) as source:
-            logging.info("Waiting for twilio caller...")
-            with tempfile.TemporaryDirectory() as tmp:
-                tmp_path = os.path.join(tmp, "mic.wav")
-                audio = self.recognizer.listen(source)
-                data = io.BytesIO(audio.get_wav_data())
-                audio_clip = AudioSegment.from_file(data)
-                audio_clip.export(tmp_path, format="wav")
-                result = self.audio_model.transcribe(tmp_path, language="english")
-        predicted_text = result["text"]
-        self.stream = None
-        return predicted_text
+        try:
+            with _TwilioSource(self.stream) as source:
+                logging.info("Waiting for twilio caller...")
+                with tempfile.TemporaryDirectory() as tmp:
+                    tmp_path = os.path.join(tmp, "mic.wav")
+                    audio = self.recognizer.listen(source)
+                    data = io.BytesIO(audio.get_wav_data())
+                    audio_clip = AudioSegment.from_file(data)
+                    audio_clip.export(tmp_path, format="wav")
+                    result = self.audio_model.transcribe(tmp_path, language=self.language)
+            return result["text"]
+        except Exception:
+            logging.exception("WhisperTwilioStream transcription failed.")
+            return ""
+        finally:
+            self.stream = None

--- a/llm_convo/audio_output.py
+++ b/llm_convo/audio_output.py
@@ -3,6 +3,7 @@ from typing import Optional
 import os
 import tempfile
 import subprocess
+import logging
 
 from gtts import gTTS
 import pyaudio
@@ -47,9 +48,97 @@ class TTSClient(ABC):
         return duration
 
 
+def _tmp_mp3_path(output_fn: Optional[str]) -> str:
+    return output_fn or os.path.join(tempfile.mkdtemp(), "tts.mp3")
+
+
 class GoogleTTS(TTSClient):
+    def __init__(self, lang: str = "en"):
+        self.lang = lang
+
     def text_to_mp3(self, text: str, output_fn: Optional[str] = None) -> str:
-        tmp_fn = output_fn or os.path.join(tempfile.mkdtemp(), "tts.mp3")
-        tts = gTTS(text, lang="en")
-        tts.save(tmp_fn)
+        tmp_fn = _tmp_mp3_path(output_fn)
+        gTTS(text, lang=self.lang).save(tmp_fn)
+        return tmp_fn
+
+
+class OpenAITTS(TTSClient):
+    """Higher-quality TTS using OpenAI's `tts-1` / `tts-1-hd` models.
+
+    Voices: alloy, echo, fable, onyx, nova, shimmer.
+    """
+
+    def __init__(
+        self,
+        voice: str = "alloy",
+        model: str = "tts-1",
+        api_key: Optional[str] = None,
+    ):
+        from openai import OpenAI
+
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY not set; cannot use OpenAITTS.")
+        self.client = OpenAI(api_key=api_key)
+        self.voice = voice
+        self.model = model
+
+    def text_to_mp3(self, text: str, output_fn: Optional[str] = None) -> str:
+        tmp_fn = _tmp_mp3_path(output_fn)
+        try:
+            response = self.client.audio.speech.create(
+                model=self.model,
+                voice=self.voice,
+                input=text,
+                response_format="mp3",
+            )
+            response.stream_to_file(tmp_fn)
+        except Exception:
+            logging.exception("OpenAI TTS failed; falling back to gTTS.")
+            gTTS(text, lang="en").save(tmp_fn)
+        return tmp_fn
+
+
+class ElevenLabsTTS(TTSClient):
+    """High-quality TTS via ElevenLabs.
+
+    Requires `pip install elevenlabs` and ELEVENLABS_API_KEY in the environment.
+    """
+
+    def __init__(
+        self,
+        voice_id: str = "21m00Tcm4TlvDq8ikWAM",  # "Rachel" default voice
+        model_id: str = "eleven_turbo_v2_5",
+        api_key: Optional[str] = None,
+    ):
+        try:
+            from elevenlabs.client import ElevenLabs
+        except ImportError as e:
+            raise RuntimeError(
+                "elevenlabs package not installed. Run: pip install elevenlabs"
+            ) from e
+
+        api_key = api_key or os.environ.get("ELEVENLABS_API_KEY")
+        if not api_key:
+            raise RuntimeError("ELEVENLABS_API_KEY not set; cannot use ElevenLabsTTS.")
+        self.client = ElevenLabs(api_key=api_key)
+        self.voice_id = voice_id
+        self.model_id = model_id
+
+    def text_to_mp3(self, text: str, output_fn: Optional[str] = None) -> str:
+        tmp_fn = _tmp_mp3_path(output_fn)
+        try:
+            audio_iter = self.client.text_to_speech.convert(
+                voice_id=self.voice_id,
+                model_id=self.model_id,
+                text=text,
+                output_format="mp3_44100_128",
+            )
+            with open(tmp_fn, "wb") as f:
+                for chunk in audio_iter:
+                    if chunk:
+                        f.write(chunk)
+        except Exception:
+            logging.exception("ElevenLabs TTS failed; falling back to gTTS.")
+            gTTS(text, lang="en").save(tmp_fn)
         return tmp_fn

--- a/llm_convo/conversation.py
+++ b/llm_convo/conversation.py
@@ -1,12 +1,26 @@
+import logging
+from typing import Optional
+
 from llm_convo.agents import ChatAgent
 
 
-def run_conversation(agent_a: ChatAgent, agent_b: ChatAgent):
+def run_conversation(agent_a: ChatAgent, agent_b: ChatAgent, max_turns: Optional[int] = None):
+    """Alternate turns between two agents until one returns an empty response
+    or `max_turns` total responses have been produced.
+    """
     transcript = []
-    while True:
-        text_a = agent_a.get_response(transcript)
-        transcript.append(text_a)
-        print("->", text_a, transcript)
-        text_b = agent_b.get_response(transcript)
-        transcript.append(text_b)
-        print("->", text_b, transcript)
+    turns = 0
+    while max_turns is None or turns < max_turns:
+        for label, agent in (("A", agent_a), ("B", agent_b)):
+            try:
+                text = agent.get_response(transcript)
+            except Exception:
+                logging.exception("Agent %s.get_response failed; ending conversation.", label)
+                return transcript
+            if not text:
+                logging.info("Agent %s returned an empty response; ending conversation.", label)
+                return transcript
+            transcript.append(text)
+            turns += 1
+            logging.info("-> [%s] %s", label, text)
+    return transcript

--- a/llm_convo/openai_io.py
+++ b/llm_convo/openai_io.py
@@ -1,23 +1,133 @@
-from typing import List, Optional
+from typing import List, Optional, Callable, Dict, Any
 import os
-import openai
+import logging
+import time
 
-openai.api_key = os.environ["OPENAI_API_KEY"]
+from openai import OpenAI, APIError, APITimeoutError, RateLimitError
+
+
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_MAX_HISTORY = 20
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RETRIES = 3
 
 
 class OpenAIChatCompletion:
-    def __init__(self, system_prompt: str, model: Optional[str] = None):
+    """Wrapper around the OpenAI chat completion API.
+
+    Supports function calling (tools), conversation history truncation, and
+    automatic retries on transient errors.
+    """
+
+    def __init__(
+        self,
+        system_prompt: str,
+        model: Optional[str] = None,
+        max_history: int = DEFAULT_MAX_HISTORY,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_handlers: Optional[Dict[str, Callable[..., str]]] = None,
+        temperature: float = 0.7,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        api_key: Optional[str] = None,
+    ):
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY not set. Export it or pass api_key= to OpenAIChatCompletion."
+            )
+
+        self.client = OpenAI(api_key=api_key, timeout=timeout, max_retries=0)
         self.system_prompt = system_prompt
-        self.model = model
+        self.model = model or DEFAULT_MODEL
+        self.max_history = max_history
+        self.tools = tools
+        self.tool_handlers = tool_handlers or {}
+        self.temperature = temperature
+        self.max_retries = max_retries
+
+    def _build_messages(self, transcript: List[str]) -> List[Dict[str, str]]:
+        # Keep only the last `max_history` turns to stay within context limits.
+        recent = transcript[-self.max_history :] if self.max_history > 0 else transcript
+        # The agent that called us speaks on odd indices of the full transcript.
+        # We need to preserve the role of each message relative to the full transcript.
+        offset = len(transcript) - len(recent)
+        messages: List[Dict[str, str]] = [{"role": "system", "content": self.system_prompt}]
+        for i, text in enumerate(recent):
+            # Even global index = user (the other party), odd = assistant (this agent).
+            role = "user" if (offset + i) % 2 == 0 else "assistant"
+            messages.append({"role": role, "content": text})
+        return messages
+
+    def _call_with_retry(self, **kwargs) -> Any:
+        last_err: Optional[Exception] = None
+        for attempt in range(self.max_retries):
+            try:
+                return self.client.chat.completions.create(**kwargs)
+            except (APITimeoutError, RateLimitError) as e:
+                last_err = e
+                wait = 2**attempt
+                logging.warning(
+                    "OpenAI transient error (attempt %d/%d): %s. Retrying in %ds.",
+                    attempt + 1,
+                    self.max_retries,
+                    e,
+                    wait,
+                )
+                time.sleep(wait)
+            except APIError as e:
+                last_err = e
+                logging.error("OpenAI API error: %s", e)
+                break
+        raise RuntimeError(f"OpenAI request failed after {self.max_retries} attempts") from last_err
 
     def get_response(self, transcript: List[str]) -> str:
-        messages = [
-            {"role": "system", "content": self.system_prompt},
-        ]
-        for i, text in enumerate(reversed(transcript)):
-            messages.insert(1, {"role": "user" if i % 2 == 0 else "assistant", "content": text})
-        output = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo" if self.model is None else self.model,
-            messages=messages,
-        )
-        return output["choices"][0]["message"]["content"]
+        messages = self._build_messages(transcript)
+
+        for _ in range(5):  # cap tool-calling loops to avoid infinite recursion
+            kwargs: Dict[str, Any] = {
+                "model": self.model,
+                "messages": messages,
+                "temperature": self.temperature,
+            }
+            if self.tools:
+                kwargs["tools"] = self.tools
+                kwargs["tool_choice"] = "auto"
+
+            response = self._call_with_retry(**kwargs)
+            message = response.choices[0].message
+
+            if not getattr(message, "tool_calls", None):
+                return (message.content or "").strip()
+
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": message.content,
+                    "tool_calls": [tc.model_dump() for tc in message.tool_calls],
+                }
+            )
+            for tool_call in message.tool_calls:
+                name = tool_call.function.name
+                handler = self.tool_handlers.get(name)
+                if handler is None:
+                    result = f"Error: no handler registered for tool '{name}'."
+                else:
+                    try:
+                        import json
+
+                        args = json.loads(tool_call.function.arguments or "{}")
+                        result = str(handler(**args))
+                    except Exception as e:
+                        logging.exception("Tool '%s' raised an error", name)
+                        result = f"Error executing {name}: {e}"
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": result,
+                    }
+                )
+
+        logging.warning("Tool-calling loop exhausted; returning last assistant content.")
+        return (message.content or "").strip()

--- a/llm_convo/twilio_io.py
+++ b/llm_convo/twilio_io.py
@@ -4,10 +4,12 @@ import os
 import base64
 import json
 import time
+import uuid
 
 from gevent.pywsgi import WSGIServer
 from twilio.rest import Client
-from flask import Flask, send_from_directory
+from twilio.request_validator import RequestValidator
+from flask import Flask, send_from_directory, request, abort
 from flask_sock import Sock
 import simple_websocket
 import audioop
@@ -26,46 +28,97 @@ XML_MEDIA_STREAM = """
 
 
 class TwilioServer:
-    def __init__(self, remote_host: str, port: int, static_dir: str):
+    def __init__(
+        self,
+        remote_host: str,
+        port: int,
+        static_dir: str,
+        validate_signature: bool = True,
+    ):
+        """Twilio bridge server.
+
+        Args:
+            remote_host: Public hostname (without scheme) Twilio uses to reach us.
+            port: Local port to bind.
+            static_dir: Directory to serve generated TTS audio from.
+            validate_signature: When True (default), reject incoming webhooks
+                that do not carry a valid X-Twilio-Signature. Set to False only
+                in local development environments without internet exposure.
+        """
         self.app = Flask(__name__)
         self.sock = Sock(self.app)
         self.remote_host = remote_host
         self.port = port
         self.static_dir = static_dir
-        self.server_thread = threading.Thread(target=self._start)
+        self.validate_signature = validate_signature
+        self.server_thread = threading.Thread(target=self._start, daemon=True)
         self.on_session = None
 
-        account_sid = os.environ["TWILIO_ACCOUNT_SID"]
-        auth_token = os.environ["TWILIO_AUTH_TOKEN"]
-        self.from_phone = os.environ["TWILIO_PHONE_NUMBER"]
+        try:
+            account_sid = os.environ["TWILIO_ACCOUNT_SID"]
+            auth_token = os.environ["TWILIO_AUTH_TOKEN"]
+            self.from_phone = os.environ["TWILIO_PHONE_NUMBER"]
+        except KeyError as e:
+            raise RuntimeError(
+                f"Missing required Twilio environment variable: {e.args[0]}"
+            ) from e
+
         self.client = Client(account_sid, auth_token)
+        self._validator = RequestValidator(auth_token)
 
         @self.app.route("/audio/<key>")
         def audio(key):
-            return send_from_directory(self.static_dir, str(int(key)) + ".mp3")
+            # `key` is a filename stem we generated ourselves — sanitize anyway
+            # to prevent path traversal.
+            safe = os.path.basename(key)
+            return send_from_directory(self.static_dir, safe + ".mp3")
 
         @self.app.route("/incoming-voice", methods=["POST"])
         def incoming_voice():
+            if self.validate_signature and not self._is_valid_twilio_request():
+                logging.warning("Rejected /incoming-voice request: invalid Twilio signature.")
+                abort(403)
             return XML_MEDIA_STREAM.format(host=self.remote_host)
 
         @self.sock.route("/audiostream", websocket=True)
         def on_media_stream(ws):
-            session = TwilioCallSession(ws, self.client, remote_host=self.remote_host, static_dir=self.static_dir)
+            session = TwilioCallSession(
+                ws, self.client, remote_host=self.remote_host, static_dir=self.static_dir
+            )
             if self.on_session is not None:
-                thread = threading.Thread(target=self.on_session, args=(session,))
+                thread = threading.Thread(target=self._run_session_safe, args=(session,), daemon=True)
                 thread.start()
-            session.start_session()
+            try:
+                session.start_session()
+            except Exception:
+                logging.exception("Twilio media stream session crashed.")
+
+    def _run_session_safe(self, session):
+        try:
+            self.on_session(session)
+        except Exception:
+            logging.exception("on_session handler raised an exception.")
+
+    def _is_valid_twilio_request(self) -> bool:
+        signature = request.headers.get("X-Twilio-Signature", "")
+        url = request.url
+        params = request.form.to_dict()
+        return self._validator.validate(url, params, signature)
 
     def start_call(self, to_phone: str):
-        self.client.calls.create(
-            twiml=XML_MEDIA_STREAM.format(host=self.remote_host),
-            to=to_phone,
-            from_=self.from_phone,
-        )
+        try:
+            return self.client.calls.create(
+                twiml=XML_MEDIA_STREAM.format(host=self.remote_host),
+                to=to_phone,
+                from_=self.from_phone,
+            )
+        except Exception:
+            logging.exception("Failed to start outgoing Twilio call to %s", to_phone)
+            raise
 
     def _start(self):
-        logging.info("Starting Twilio Server")
-        WSGIServer(("0.0.0.0", self.port), self.app).serve_forever()
+        logging.info("Starting Twilio Server on port %d", self.port)
+        WSGIServer(("0.0.0.0", self.port), self.app, log=None).serve_forever()
 
     def start(self):
         self.server_thread.start()
@@ -79,6 +132,7 @@ class TwilioCallSession:
         self.remote_host = remote_host
         self.static_dir = static_dir
         self._call = None
+        self._audio_keys: dict = {}
 
     def media_stream_connected(self):
         return self._call is not None
@@ -88,35 +142,61 @@ class TwilioCallSession:
             try:
                 message = self.ws.receive()
             except simple_websocket.ws.ConnectionClosed:
-                logging.warn("Call media stream connection lost.")
+                logging.warning("Call media stream connection lost.")
+                break
+            except Exception:
+                logging.exception("Unexpected error reading from media stream.")
                 break
             if message is None:
-                logging.warn("Call media stream closed.")
+                logging.warning("Call media stream closed.")
                 break
 
-            data = json.loads(message)
-            if data["event"] == "start":
-                logging.info("Call connected, " + str(data["start"]))
+            try:
+                data = json.loads(message)
+            except json.JSONDecodeError:
+                logging.warning("Received non-JSON media stream message; skipping.")
+                continue
+
+            event = data.get("event")
+            if event == "start":
+                logging.info("Call connected, %s", data.get("start"))
                 self._call = self.client.calls(data["start"]["callSid"])
-            elif data["event"] == "media":
-                media = data["media"]
-                chunk = base64.b64decode(media["payload"])
-                if self.sst_stream.stream is not None:
-                    self.sst_stream.stream.write(audioop.ulaw2lin(chunk, 2))
-            elif data["event"] == "stop":
+            elif event == "media":
+                media = data.get("media", {})
+                payload = media.get("payload")
+                if not payload:
+                    continue
+                try:
+                    chunk = base64.b64decode(payload)
+                    if self.sst_stream.stream is not None:
+                        self.sst_stream.stream.write(audioop.ulaw2lin(chunk, 2))
+                except Exception:
+                    logging.exception("Failed to process media chunk.")
+            elif event == "stop":
                 logging.info("Call media stream ended.")
                 break
 
     def get_audio_fn_and_key(self, text: str):
-        key = str(abs(hash(text)))
+        # Use UUID-based keys to avoid hash collisions between distinct utterances.
+        if text in self._audio_keys:
+            key = self._audio_keys[text]
+        else:
+            key = uuid.uuid4().hex
+            self._audio_keys[text] = key
         path = os.path.join(self.static_dir, key + ".mp3")
         return key, path
 
     def play(self, audio_key: str, duration: float):
-        self._call.update(
-            twiml=f'<Response><Play>https://{self.remote_host}/audio/{audio_key}</Play><Pause length="60"/></Response>'
-        )
-        time.sleep(duration + 0.2)
+        if self._call is None:
+            logging.warning("Tried to play audio before call connected; skipping.")
+            return
+        try:
+            self._call.update(
+                twiml=f'<Response><Play>https://{self.remote_host}/audio/{audio_key}</Play><Pause length="60"/></Response>'
+            )
+            time.sleep(duration + 0.2)
+        except Exception:
+            logging.exception("Failed to play audio on Twilio call.")
 
     def start_session(self):
         self._read_ws()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black~=23.1
 gTTS~=2.3
-openai~=0.28
+openai>=1.40,<2
 SpeechRecognition~=3.10
 pyaudio~=0.2
 pydub~=0.25
@@ -9,3 +9,5 @@ gevent~=23.9.1
 twilio~=8.8.0
 flask~=2.3
 flask_sock~=0.6
+# Optional: high-quality TTS provider
+# elevenlabs>=1.0


### PR DESCRIPTION
## Summary

Hardens the Twilio ↔ ChatGPT bridge and unlocks production-grade use cases.

- **OpenAI SDK v1+** migration with retries, history truncation, and configurable model (defaults to `gpt-4o-mini`).
- **Function calling (tools)** so the LLM can look up orders, schedule appointments, hit internal APIs, etc.
- **Twilio webhook signature validation** on `/incoming-voice` — rejects forged requests with `403`.
- **Premium TTS providers**: `OpenAITTS` (alloy/nova/…) and `ElevenLabsTTS`, both with automatic fallback to gTTS on failure.
- **Robust error handling** across the call path — a failed LLM call, TTS request, or transcription no longer crashes the bridge.
- **Misc fixes**: UUID-based audio cache keys (no more hash collisions), path-traversal guard on `/audio/<key>`, configurable Whisper language, daemon server thread.

## Changes

| File | Change |
|---|---|
| `llm_convo/openai_io.py` | Rewritten for OpenAI SDK v1+, with retries, `max_history`, and tool-calling loop. |
| `llm_convo/twilio_io.py` | Added `RequestValidator`, UUID audio keys, try/except on websocket/media paths. |
| `llm_convo/audio_output.py` | New `OpenAITTS` and `ElevenLabsTTS` classes with gTTS fallback. |
| `llm_convo/agents.py` | `OpenAIChat` accepts `tools`/`tool_handlers`; fallback phrase on LLM failure. |
| `llm_convo/audio_input.py` | Configurable transcription language; safe failure mode. |
| `llm_convo/conversation.py` | Optional `max_turns`; ends cleanly on agent error. |
| `requirements.txt` | Bumped `openai` to `>=1.40,<2`; optional `elevenlabs`. |
| `README.md` | Architecture table, env-var reference, tool-calling and premium-TTS examples, cost estimates. |

## Breaking changes

- Requires `openai>=1.40`. Callers using the deprecated `openai.ChatCompletion.create` interface directly (outside `OpenAIChatCompletion`) must update.
- `OPENAI_API_KEY` is now validated lazily inside `OpenAIChatCompletion.__init__` instead of at module import time. Code that relied on the import-time check should adjust.
